### PR TITLE
Fix selectors and document keyword #174 #175

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+What's changed since pre-release v0.9.0-B2107010:
+
+- Bug fixes:
+  - Fixed failed to get document definitions with selectors. [#174](https://github.com/Microsoft/PSDocs/issues/174)
+  - Fixed PowerShell command completion `Document` keyword. [#175](https://github.com/Microsoft/PSDocs/issues/175)
+
 ## v0.9.0-B2107010 (pre-release)
 
 What's changed since pre-release v0.9.0-B2107002:

--- a/src/PSDocs/PSDocs.psm1
+++ b/src/PSDocs/PSDocs.psm1
@@ -446,7 +446,7 @@ function Document {
         [ScriptBlock]$If,
 
         [Parameter(Mandatory = $False)]
-        [String[]]$When
+        [String[]]$With
     )
     begin {
          # This is just a stub to improve authoring and discovery

--- a/src/PSDocs/Pipeline/GetPipeline.cs
+++ b/src/PSDocs/Pipeline/GetPipeline.cs
@@ -35,6 +35,7 @@ namespace PSDocs.Pipeline
             : base(context, source)
         {
             _Runspace = new RunspaceContext(Context);
+            HostHelper.ImportResource(Source, _Runspace);
         }
 
         public override void End()

--- a/tests/PSDocs.Tests/PSDocs.Selector.Tests.ps1
+++ b/tests/PSDocs.Tests/PSDocs.Selector.Tests.ps1
@@ -40,14 +40,32 @@ Describe 'PSDocs selectors' -Tag 'Selector' {
     $docFilePath = Join-Path -Path $here -ChildPath 'FromFile.Selector.Doc.ps1';
     $selectorFilePath = Join-Path -Path $here -ChildPath 'Selectors.Doc.yaml';
 
-    Context 'With -InputObject' {
+    Context 'Invoke definitions' {
         $invokeParams = @{
             Path = @($docFilePath, $selectorFilePath)
         }
+        
         It 'Generates documentation for matching objects' {
             $result = @($dummyObject | Invoke-PSDocument @invokeParams -Name 'Selector.WithInputObject' -PassThru);
             $result | Should -Not -BeNullOrEmpty;
             $result | Should -Not -Be 'Name: HashName';
+        }
+    }
+
+    Context 'Get definitions' {
+        It 'With selector' {
+            $getParams = @{
+                Path = @($docFilePath, $selectorFilePath)
+            }
+            $result = @(Get-PSDocument @getParams)
+            $result | Should -Not -BeNullOrEmpty;
+        }
+
+        It 'Missing selector' {
+            $getParams = @{
+                Path = @($docFilePath)
+            }
+            { Get-PSDocument @getParams -ErrorAction Stop } | Should -Throw -ErrorId 'PSDocs.Parse.SelectorNotFound';
         }
     }
 }

--- a/tests/PSDocs.Tests/TestModule/docs/Selector.Doc.yaml
+++ b/tests/PSDocs.Tests/TestModule/docs/Selector.Doc.yaml
@@ -1,0 +1,13 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+---
+# Synopsis: A selector for unit testing.
+apiVersion: github.com/microsoft/PSDocs/v1
+kind: Selector
+metadata:
+  name: AlwaysTrue
+spec:
+  if:
+    field: '__not_value__'
+    exists: false

--- a/tests/PSDocs.Tests/TestModule/docs/Test.Doc.ps1
+++ b/tests/PSDocs.Tests/TestModule/docs/Test.Doc.ps1
@@ -5,6 +5,6 @@ Document 'TestDocument1' {
     "Culture=$($LocalizedData.Culture)";
 }
 
-Document 'TestDocument2' {
+Document 'TestDocument2' -With 'AlwaysTrue' {
 
 }


### PR DESCRIPTION
## PR Summary

- Fixed failed to get document definitions with selectors. #174
- Fixed PowerShell command completion `Document` keyword. #175

Fixes #174 
Fixes #175 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSDocs/blob/main/CHANGELOG.md) has been updated with change under unreleased section
