### PR TITLE
Pre-release v0.9.0-B2107015

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.9.0-B2107015 (pre-release)
+
 What's changed since pre-release v0.9.0-B2107010:
 
 - Bug fixes:


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v0.9.0-B2107010:

- Bug fixes:
  - Fixed failed to get document definitions with selectors. #174
  - Fixed PowerShell command completion `Document` keyword. #175

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
