### PR TITLE
docs: Add archive notice pointing to Azure/PSDocs.Azure

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,10 @@
 # Contributing
 
+> [!IMPORTANT]
+> **This repository is archived and is no longer accepting contributions.**
+> All future work on PSDocs is consolidated under **[Azure/PSDocs.Azure](https://github.com/Azure/PSDocs.Azure)**.
+> Please contribute there instead.
+
 This project welcomes contributions and suggestions. Most contributions require you to
 agree to a Contributor License Agreement (CLA) declaring that you have the right to,
 and actually do, grant us the rights to use your contribution. For details, visit

--- a/README.md
+++ b/README.md
@@ -1,16 +1,24 @@
 # PSDocs
 
+> [!IMPORTANT]
+> **This repository is archived and is no longer actively maintained.**
+>
+> All future work on PSDocs is consolidated under **[Azure/PSDocs.Azure](https://github.com/Azure/PSDocs.Azure)**.
+>
+> - Please open new issues, discussions, and pull requests in [Azure/PSDocs.Azure](https://github.com/Azure/PSDocs.Azure).
+> - Issues, discussions, and pull requests in this repository will no longer be monitored.
+> - Existing published module versions remain available on the PowerShell Gallery, but no new releases will be made from this repository.
+>
+> This repository remains available in read-only form for historical reference.
+
 A PowerShell module with commands to generate markdown from objects using PowerShell syntax.
 
 ![ci-badge]
 
 ## Support
 
-This project uses GitHub Issues to track bugs and feature requests.
-Please search the existing issues before filing new issues to avoid duplicates.
-
-- For new issues, file your bug or feature request as a new [issue].
-- For help, discussion, and support questions about using this project, join or start a [discussion].
+New issues, feature requests, and discussions should be raised in [Azure/PSDocs.Azure](https://github.com/Azure/PSDocs.Azure).
+Issues and discussions in this repository are no longer monitored.
 
 Support for this project/ product is limited to the resources listed above.
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,12 +1,19 @@
 # Support
 
+> [!IMPORTANT]
+> **This repository is archived and is no longer actively maintained.**
+> All future work on PSDocs is consolidated under **[Azure/PSDocs.Azure](https://github.com/Azure/PSDocs.Azure)**.
+> Please raise new issues and discussions in [Azure/PSDocs.Azure](https://github.com/Azure/PSDocs.Azure) instead.
+
 ## How to file issues and get help
 
-This project uses GitHub Issues to track bugs and feature requests.
-Please search the existing issues before filing new issues to avoid duplicates.
+New issues and feature requests should be raised in [Azure/PSDocs.Azure](https://github.com/Azure/PSDocs.Azure).
+Issues and discussions in this repository are no longer monitored.
 
-- For new issues, file your bug or feature request as a new [issue].
-- For help, discussion, and support questions about using this project, join or start a [discussion].
+The links below are retained for historical reference only:
+
+- Existing [issue] history.
+- Existing [discussion] history.
 
 ## Microsoft Support Policy
 


### PR DESCRIPTION
## Summary

Adds a prominent notice at the top of the key entry-point docs indicating that this repository is archived and that all future work is consolidated under [Azure/PSDocs.Azure](https://github.com/Azure/PSDocs.Azure).

## Changes

- **`README.md`** — `[!IMPORTANT]` callout at the very top of the file, plus the **Support** section updated to direct new issues/discussions to Azure/PSDocs.Azure.
- **`SUPPORT.md`** — archive callout and updated guidance that issues/discussions here are no longer monitored; existing links retained for historical reference.
- **`CONTRIBUTING.md`** — callout noting the repo no longer accepts contributions.

The notices use GitHub alert syntax (`> [!IMPORTANT]`) so they render as a highlighted banner on github.com.

## Notes

Docs-only change; no code or build changes.